### PR TITLE
fixed site nav css

### DIFF
--- a/docs/_includes/primary-nav-items.html
+++ b/docs/_includes/primary-nav-items.html
@@ -1,6 +1,6 @@
-<ul>
+<ul class="nav-links">
     {% for p in site.data.primary_nav %}
-    <li
+    <li class="page-link"
             {%- if p.link == '/' -%}
     {% if page.url == p.link %} class="current" {%- endif %}
     {%- else -%}

--- a/docs/_sass/minima/_layout.scss
+++ b/docs/_sass/minima/_layout.scss
@@ -17,7 +17,7 @@
   letter-spacing: -1px;
   margin-bottom: 0;
   float: left;
-
+  margin-right: -100px;
   &,
   &:visited {
     color: $grey-color-dark;
@@ -42,7 +42,7 @@
 
     // Gaps between nav items, but not on the last one
     &:not(:last-child) {
-      margin-right: 20px;
+      margin-bottom: 4px;
     }
   }
 


### PR DESCRIPTION
Tested this on both Chrome and Firefox, renders as it should

Nav links have a slight overlap on the image right before disappearing when in firefox and the emoji are displayed, 

A lot of the special characters don't display properly in either Chrome or Firefox