### PR TITLE
Fix wrangler deploys (#2263)

### DIFF
--- a/.github/workflows/wrangler-action.yml
+++ b/.github/workflows/wrangler-action.yml
@@ -11,18 +11,20 @@ jobs:
     name: Magic
     steps:
       - uses: actions/checkout@v3
-      - name: Publish
+      - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'workers.dev/magic'
+          command: 'deploy'
   preston:
     runs-on: ubuntu-latest
     name: Preston
     steps:
       - uses: actions/checkout@v3
-      - name: Publish
+      - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'workers.dev/preston'
+          command: 'deploy'

--- a/.github/workflows/wrangler-action.yml
+++ b/.github/workflows/wrangler-action.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'workers.dev/preston'
-          command: 'deploy'
+          command: deploy

--- a/.github/workflows/wrangler-action.yml
+++ b/.github/workflows/wrangler-action.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           workingDirectory: 'workers.dev/magic'
-          command: 'deploy'
+          command: deploy
   preston:
     runs-on: ubuntu-latest
     name: Preston

--- a/workers.dev/magic/wrangler.toml
+++ b/workers.dev/magic/wrangler.toml
@@ -1,4 +1,4 @@
 name = "magic"
-type = "webpack"
 account_id = "716a4fb5f5ec1ff5ec1a990259927847"
 workers_dev = true
+main = "index.js"

--- a/workers.dev/preston/wrangler.toml
+++ b/workers.dev/preston/wrangler.toml
@@ -1,4 +1,4 @@
 name = "preston"
-type = "webpack"
 account_id = "716a4fb5f5ec1ff5ec1a990259927847"
 workers_dev = true
+main = "index.js"


### PR DESCRIPTION
Added main attribute in wrangler.toml for clear entry points.
Removed type attribute from wrangler.toml as it's no longer required.
Replaced deprecated publish command with deploy in GitHub Actions workflow.