### PR TITLE
Update super-linter.yml

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,7 +28,7 @@ jobs:
           VALIDATE_BASH: true
           VALIDATE_BASH_EXEC: true
           # VALIDATE_EDITORCONFIG: true
-          VALIDATE_GO: true
+          VALIDATE_GO: false
           VALIDATE_MARKDOWN: true
           VALIDATE_PHP: true
           VALIDATE_PYTHON_FLAKE8: true


### PR DESCRIPTION
https://github.com/slurpcode/slurp/actions/runs/7965475600/job/21745069496?pr=2565

[FATAL]   Set VALIDATE_GO to false to avoid false positives due to analyzing Go files in the /github/workspace directory individually instead of considering them in the context of a Go module.