### PR TITLE
bugfix: csvlint is failing in circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
           # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           keys:
             - v1-pkg-cache
-      - run: go get -u github.com/Clever/csvlint/cmd/csvlint
+      - run: go install github.com/Clever/csvlint/cmd/csvlint@latest
       - run:
           name: 🧹 Run CSV lint
           command: |


### PR DESCRIPTION
This PR updates the circleci workflow where `csvlint` is failing.

`go get` was [deprecated](https://go.dev/doc/go-get-install-deprecation) as  a method of installing modules as of version `1.18`.
Workflow is using `go:1.23.2` so `go install` is required.

Fixes #2791.