### PR TITLE
chore(renovate): migrate config to 'config:recommended'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "assignees": [
     "jbampton"


### PR DESCRIPTION
### Summary
This PR updates the Renovate configuration to the new format as suggested by Renovate’s migration notice.

### Changes
- Replaced `config:base` with `config:recommended`
- Retained existing assignees and labels

### Why
The previous configuration format is deprecated and triggered a “Config migration necessary” warning in Renovate logs.

Fixes #2575
