### PR TITLE
chore(deps): upgrade Pillow to >=12.2.0 to remediate CVE-2026-40192

### DIFF
--- a/charts/requirements.txt
+++ b/charts/requirements.txt
@@ -1,3 +1,5 @@
 matplotlib
+# Ensure Pillow >=12.2.0 because matplotlib may pull Pillow as a dependency
+pillow>=12.2.0
 pandas
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@ chromedriver-autoinstaller
 defusedxml
 flake8
 matplotlib
+# Pin Pillow to mitigate CVE-2026-40192 (upgrade to 12.2.0)
+# See: https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5xc4v2j
+pillow>=12.2.0
 pandas
 pylint
 requests


### PR DESCRIPTION
**Summary**


This PR upgrades the Pillow requirement to >=12.2.0 to address CVE-2026-40192 (FITS decompression bomb vulnerability).

*Files changed*

- requirements.txt
- charts/requirements.txt

*Why*

Pillow versions 10.3.0 through 12.1.1 allow unbounded GZIP decompression when decoding FITS images, which may lead to OOM/DoS. Upgrading to 12.2.0+ contains the fix.

*References*

Advisory: https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5xc4v2j
CVE: https://www.mend.io/vulnerability-database/CVE-2026-40192

*Testing / Notes for reviewer*

Run the test-suite and any image-handling smoke tests (esp. code paths using matplotlib).
If you maintain a lockfile (Pipfile.lock / poetry.lock / requirements-locked.txt), regenerate it and verify CI.
If you prefer a strict pin instead of a minimum version, change pillow>=12.2.0 → pillow==12.2.0.

*Risk*

Low: this is a dependency upgrade; be mindful of runtime changes only if your code relies on Pillow internals.

*Suggested next steps after merge*

Update lockfiles and run CI.
Re-run dependency scan to confirm vulnerability resolved.
Commit message (conventional commit style) Subject (<=50 chars)

chore(deps): pin Pillow >= 12.2.0 to remediate CVE-2026-40192
Body (wrap at ~72 chars)

Upgrade Pillow to 12.2.0+ to fix a decompression-bomb vulnerability (CVE-2026-40192) that affected Pillow versions 10.3.0 through 12.1.1. This change updates:

- requirements.txt
- charts/requirements.txt

*References:*

```
- https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5xc4v2j
- https://www.mend.io/vulnerability-database/CVE-2026-40192
```

*Notes:*

- If you use lockfiles, regenerate them after merge.
- If you want an exact version pin, replace >=12.2.0 with ==12.2.0.